### PR TITLE
Restored missing section of install script

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -40,3 +40,11 @@ ynh_config_add_fail2ban --logpath="/var/log/nginx/${domain}-error.log" --failreg
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
+
+ynh_systemctl --service="$app" --action="start"
+
+#================================================
+# END OF SCRIPT
+#================================================
+
+ynh_script_progression "Installation of $app completed"


### PR DESCRIPTION
## Problem

- The final section of the install script was missing, so the systemd service did not start automatically and the completed message did not show.

## Solution

- I added back the last parts

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
